### PR TITLE
Prevent error with empty YAML file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 django_yaml_redirects.egg-info/
 dist
+*.pyc

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,3 +2,4 @@ v0.1, 2016-04-06 -- Initial release (renamed from django-json-redirects)
 v0.2, 2016-04-06 -- Use Author's full name
 v0.3, 2016-04-06 -- Simplify handling of encodings
 v0.4, 2016-04-07 -- Use RedirectView so as to expand %(name)s variables
+v0.5.4, 2016-10-19 -- Prevent error for empty yaml file

--- a/django_yaml_redirects/__init__.py
+++ b/django_yaml_redirects/__init__.py
@@ -60,9 +60,10 @@ def load_redirects():
     if exists(redirect_file_path):
         with open(redirect_file_path) as redirect_file:
             redirect_dict = yaml.load(redirect_file.read())
-            redirect_patterns = list(map(
-                convert_to_url_pattern,
-                redirect_dict.items()
-            ))
+            if redirect_dict:
+                redirect_patterns = list(map(
+                    convert_to_url_pattern,
+                    redirect_dict.items()
+                ))
 
     return redirect_patterns

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,8 @@ from setuptools import setup
 
 setup(
     name='django-yaml-redirects',
-    version='0.5.3',
-    author='Robin Winslow',
-    author_email='robin@canonical.com',
+    version='0.5.4',
+    author='Canonical Webteam',
     url='https://github.com/ubuntudesign/django-yaml-redirects',
     packages=[
         'django_yaml_redirects'


### PR DESCRIPTION
This change prevents empty YAML files, or files containing only comments, from causing an error.

Also bumping the version and updating the author to Canonical Webteam